### PR TITLE
Allow to merge multiple sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ provider:
 ```
 This will merge everything in `path/to/other.yml` to provider. Duplicate properties will be overridden by the merged value.
 
+It is possible to use array if you want to merge variables from multiple sources:
+```yaml
+provider:
+    name: aws
+    $<<:
+      - ${file:path/to/other.yml}
+      - ${file:path/to/another.yml}
+```
+This will merge everything in `path/to/other.yml`, then in `file:path/to/another.yml` to provider. Duplicate properties will be overridden by the merged value.
+
 **caveat**: `serverless print` will not show the merged configuration. This command reloads and parses serverless.yml a second time with no hooks for plugins to tie into.
 
 # Contributing

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ class ServerlessMergeConfig {
 
     this.hooks = {
       'before:package:initialize': this.mergeConfig.bind(this),
-      'before:offline:start:init': this.mergeConfig.bind(this)
+      'before:offline:start:init': this.mergeConfig.bind(this),
+      'before:invoke:local:invoke': this.mergeConfig.bind(this)
     }
   }
 
@@ -29,13 +30,23 @@ class ServerlessMergeConfig {
         this.deepMerge(value)
       }
       if (key === '$<<') {
-        if (isPlainObject(value)) {
-          // Only merge objects
-          assign(collection, value)
+        if (isArray(value)) {
+          value.forEach((subValue) => {
+            this.assignValue(collection, subValue)
+          });
+        } else {
+          this.assignValue(collection, value);
         }
         unset(obj, key)
       }
     })
+  }
+
+  assignValue(collection, value) {
+    if (isPlainObject(value)) {
+      // Only merge objects
+      assign(collection, value);
+    }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -33,19 +33,19 @@ class ServerlessMergeConfig {
         if (isArray(value)) {
           value.forEach((subValue) => {
             this.assignValue(collection, subValue)
-          });
+          })
         } else {
-          this.assignValue(collection, value);
+          this.assignValue(collection, value)
         }
         unset(obj, key)
       }
     })
   }
 
-  assignValue(collection, value) {
+  assignValue (collection, value) {
     if (isPlainObject(value)) {
       // Only merge objects
-      assign(collection, value);
+      assign(collection, value)
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
       "node": true,
       "jest": true
     }
+  },
+  "jest": {
+      "testURL": "http://localhost/",
+      "testEnvironment": "node"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -54,6 +54,13 @@ describe('serverless-merge-config', () => {
     })
   })
 
+  it('should merge arrays of objects', () => {
+    let config = {provider: {name: 'aws', '$<<': [{foo: 'bar'}, {egg: 'spam'}]}}
+    let plugin = constructPlugin(config)
+    plugin.mergeConfig()
+    expect(plugin.serverless.service).toEqual({provider: {name: 'aws', foo: 'bar', egg: 'spam'}})
+  })
+
   it('should not merge arrays', () => {
     let config = {provider: {name: 'aws', '$<<': [1, 2, 3]}}
     let plugin = constructPlugin(config)


### PR DESCRIPTION
Example:
```yaml
provider:
    name: aws
    $<<:
      - ${file:path/to/other.yml}
      - ${file:path/to/another.yml}
```

Also, add hook to do it before local invoke. Otherwise, locally invoked
function doesn't get the correct values. For example, when using merge
for environment values.